### PR TITLE
Add Liebigschule Giessen

### DIFF
--- a/lib/domains/at/or/klg.txt
+++ b/lib/domains/at/or/klg.txt
@@ -1,0 +1,1 @@
+Konrad Lorenz Gymnasium

--- a/lib/domains/ch/kme.txt
+++ b/lib/domains/ch/kme.txt
@@ -1,0 +1,1 @@
+Kantonale Maturitätsschule für Erwachsene Zürich

--- a/lib/domains/de/ernestinum-rinteln.txt
+++ b/lib/domains/de/ernestinum-rinteln.txt
@@ -1,0 +1,1 @@
+Gymnasium Ernestinum Rinteln

--- a/lib/domains/de/lo-net2/nw/fvsg-ob.txt
+++ b/lib/domains/de/lo-net2/nw/fvsg-ob.txt
@@ -1,0 +1,1 @@
+Freiherr-vom-Stein Gymnasium Oberhausen

--- a/lib/domains/hr/grad.txt
+++ b/lib/domains/hr/grad.txt
@@ -1,0 +1,1 @@
+aculty of Civil Engineering University of Zagreb

--- a/lib/domains/hr/grad.txt
+++ b/lib/domains/hr/grad.txt
@@ -1,1 +1,1 @@
-aculty of Civil Engineering University of Zagreb
+Faculty of Civil Engineering University of Zagreb

--- a/lib/domains/jp/ac/osaka-u.txt
+++ b/lib/domains/jp/ac/osaka-u.txt
@@ -1,0 +1,1 @@
+Osaka University

--- a/lib/domains/nl/ichthuskampen/leerling.txt
+++ b/lib/domains/nl/ichthuskampen/leerling.txt
@@ -1,0 +1,1 @@
+Ichthus College Kampen 

--- a/lib/domains/uk/org/bicestertechstudio.txt
+++ b/lib/domains/uk/org/bicestertechstudio.txt
@@ -1,0 +1,1 @@
+Bicester Technology Studio


### PR DESCRIPTION
School Website: http://liebigschule-giessen.de/

School Type: 
- Gymnasium

IT related courses: 
- as elective in class 9 and 10 (2 Years)
- choosable in class 11 (1 Year)
- choosable in A Level as advanced course (class 12 and 13) (2 Years)
- choosable in A Level as basic course (class 12 and 13) (2 Years)

Curricula for classes 9 and 10:
- 9: http://liebigschule-giessen.de/index.php?option=com_docman&view=download&alias=362-informatik-jahresplan-jg9-g9&category_slug=informatik-1&Itemid=289
- 10: http://liebigschule-giessen.de/index.php?option=com_docman&view=download&alias=361-informatik-jahresplan-jg10-g9&category_slug=informatik-1&Itemid=289

Curricula for classes 11-13 given by the Ministry of Education
- https://kultusministerium.hessen.de/sites/default/files/media/kcgo-in.pdf

Proof of Email is being used by teachers and IT-students:
![proof](https://cloud.githubusercontent.com/assets/22458829/18997473/ccc62594-8734-11e6-874c-83190b935e66.PNG)
